### PR TITLE
chore: bump v0.0.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.changelog/
+
 # Logs
 logs
 *.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+## v0.0.2 (2020-08-14)
+
+#### :bug: Type: Bug
+
+- [#7](https://github.com/caddijp/frontend/pull/7) fix: registry urls ([@9renpoto](https://github.com/9renpoto))
+
+#### Committers: 1
+
+- Keisuke Kan ([@9renpoto](https://github.com/9renpoto))

--- a/lerna.json
+++ b/lerna.json
@@ -12,5 +12,5 @@
   "packages": ["packages/*"],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "0.0.1"
+  "version": "0.0.2"
 }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@caddijp/components",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "CADDi ui components built with React.",
   "repository": "git+https://github.com/caddijp/caddi-components.git",
   "main": "lib/index.js",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@caddijp/eslint-config",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "license": "MIT",
   "main": "index.js",
   "scripts": {

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@caddijp/stylelint-config",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "license": "MIT",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## v0.0.2 (2020-08-14)

#### :bug: Type: Bug

- [#7](https://github.com/caddijp/frontend/pull/7) fix: registry urls ([@9renpoto](https://github.com/9renpoto))

#### Committers: 1

- Keisuke Kan ([@9renpoto](https://github.com/9renpoto))