### PR TITLE
fix: modal component

### DIFF
--- a/packages/components/src/Modal/Modal.tsx
+++ b/packages/components/src/Modal/Modal.tsx
@@ -3,16 +3,16 @@ import React from 'react';
 import ReactModal, { Props as ReactModalProps, Styles as ReactModalStyles } from 'react-modal';
 import styled from 'styled-components';
 
-export interface ModalProps extends ReactModalProps {
+export type ModalProps = ReactModalProps & {
   title: string;
-  footer?: JSX.Element;
-}
+  footer?: React.ReactNode;
+};
 
 const customStyles: ReactModalStyles = {
   /* stylelint-disable selector-type-no-unknown */
   overlay: {
     background: 'rgba(72, 82, 109, 0.2)',
-  },
+  }
   /* stylelint-enable selector-type-no-unknown */
 };
 
@@ -50,6 +50,7 @@ const StyledModalTitle = styled.div`
 const StyledCloseButton = styled.button`
   width: 55px;
   height: 55px;
+  cursor: pointer;
   background: none;
   border: none;
 `;

--- a/packages/components/src/Modal/Modal.tsx
+++ b/packages/components/src/Modal/Modal.tsx
@@ -12,7 +12,7 @@ const customStyles: ReactModalStyles = {
   /* stylelint-disable selector-type-no-unknown */
   overlay: {
     background: 'rgba(72, 82, 109, 0.2)',
-  }
+  },
   /* stylelint-enable selector-type-no-unknown */
 };
 


### PR DESCRIPTION
fix below error and tiny stuff

```
ERROR in /Users/hiroaki_yamashita/workspace/herodotus/herodotus-ui/src/components/Search/SearchResult.tsx
[tsl] ERROR in /Users/hiroaki_yamashita/workspace/herodotus/herodotus-ui/src/components/Search/SearchResult.tsx(198,9)
      TS2322: Type '{ children: Element[]; title: string; isOpen: boolean; onRequestClose: () => void; footer: Element; }' is not assignable to type 'IntrinsicAttributes & ModalProps & { children?: ReactNode; }'.
  Property 'isOpen' does not exist on type 'IntrinsicAttributes & ModalProps & { children?: ReactNode; }'.
```