### PR TITLE
chore: bump v0.0.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# v0.0.13 (2020-09-08)
+
+#### :rocket: Type: Feature
+
+- `components`
+  - [#59](https://github.com/caddijp/frontend/pull/59) chore(deps): pin dependencies ([@renovate[bot]](https://github.com/apps/renovate))
+- `components`, `eslint-config`
+  - [#58](https://github.com/caddijp/frontend/pull/58) chore: update dependencies ([@9renpoto](https://github.com/9renpoto))
+
+#### Committers: 1
+
+- Keisuke Kan ([@9renpoto](https://github.com/9renpoto))
+
 ## v0.0.12 (2020-08-28)
 
 #### :bug: Type: Bug

--- a/lerna.json
+++ b/lerna.json
@@ -8,15 +8,9 @@
       "Type: Feature": ":rocket: Type: Feature"
     }
   },
-  "ignoreChanges": [
-    "**/__fixtures__/**",
-    "**/__tests__/**",
-    "**/*.md"
-  ],
-  "packages": [
-    "packages/*"
-  ],
+  "ignoreChanges": ["**/__fixtures__/**", "**/__tests__/**", "**/*.md"],
+  "packages": ["packages/*"],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "0.0.12"
+  "version": "0.0.13"
 }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@caddijp/components",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "CADDi ui components built with React.",
   "license": "MIT",
   "repository": "git@github.com:caddijp/frontend.git",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@caddijp/eslint-config",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "license": "MIT",
   "main": "index.js",
   "scripts": {

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@caddijp/stylelint-config",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {


### PR DESCRIPTION
# v0.0.13 (2020-09-08)

#### :rocket: Type: Feature

- `components`
  - [#59](https://github.com/caddijp/frontend/pull/59) chore(deps): pin dependencies ([@renovate[bot]](https://github.com/apps/renovate))
- `components`, `eslint-config`
  - [#58](https://github.com/caddijp/frontend/pull/58) chore: update dependencies ([@9renpoto](https://github.com/9renpoto))

#### Committers: 1

- Keisuke Kan ([@9renpoto](https://github.com/9renpoto))