### PR TITLE
docs: bump v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## v0.2.0 (2021-01-28)
+
+#### :rocket: Type: Feature
+
+- `components`
+  - [#202](https://github.com/caddijp/frontend/pull/202) feat(packages/components): add duration prop to Notification ([@tkiryu](https://github.com/tkiryu))
+- Other
+  - [#188](https://github.com/caddijp/frontend/pull/188) chore(deps): update dependency eslint-plugin-react to v7.22.0 ([@renovate[bot]](https://github.com/apps/renovate))
+
+#### Committers: 2
+
+- Keisuke Kan ([@9renpoto](https://github.com/9renpoto))
+- Tatsushi Kiryu ([@tkiryu](https://github.com/tkiryu))
+
 ## v0.1.1 (2020-12-14)
 
 #### :bug: Type: Bug

--- a/lerna.json
+++ b/lerna.json
@@ -12,5 +12,5 @@
   "packages": ["packages/*"],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "0.1.1"
+  "version": "0.2.0"
 }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@caddijp/components",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "CADDi ui components built with React.",
   "license": "MIT",
   "repository": "git@github.com:caddijp/frontend.git",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@caddijp/eslint-config",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "license": "MIT",
   "main": "index.js",
   "scripts": {

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@caddijp/stylelint-config",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@caddijp/tsconfig",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Shared TypeScript config for CADDi projects",
   "license": "MIT",
   "main": "tsconfig.json",


### PR DESCRIPTION
## v0.2.0 (2021-01-28)

#### :rocket: Type: Feature

- `components`
  - [#202](https://github.com/caddijp/frontend/pull/202) feat(packages/components): add duration prop to Notification ([@tkiryu](https://github.com/tkiryu))
- Other
  - [#188](https://github.com/caddijp/frontend/pull/188) chore(deps): update dependency eslint-plugin-react to v7.22.0 ([@renovate[bot]](https://github.com/apps/renovate))

#### Committers: 2

- Keisuke Kan ([@9renpoto](https://github.com/9renpoto))
- Tatsushi Kiryu ([@tkiryu](https://github.com/tkiryu))