### PR TITLE
chore: bump v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## v0.2.1 (2021-03-19)
+
+#### :bug: Type: Bug
+
+- [#245](https://github.com/caddijp/frontend/pull/245) fix: typo ([@9renpoto](https://github.com/9renpoto))
+
+#### :rocket: Type: Feature
+
+- `components`
+  - [#244](https://github.com/caddijp/frontend/pull/244) feat: use npm workspace ([@9renpoto](https://github.com/9renpoto))
+
+#### Committers: 1
+
+- Keisuke Kan ([@9renpoto](https://github.com/9renpoto))
+
 ## v0.2.0 (2021-01-28)
 
 #### :rocket: Type: Feature

--- a/lerna.json
+++ b/lerna.json
@@ -12,5 +12,5 @@
   "packages": ["packages/*"],
   "npmClient": "npm",
   "useWorkspaces": true,
-  "version": "0.2.0"
+  "version": "0.2.1"
 }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@caddijp/components",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "CADDi ui components built with React.",
   "license": "MIT",
   "repository": "git@github.com:caddijp/frontend.git",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@caddijp/eslint-config",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "license": "MIT",
   "main": "index.js",
   "scripts": {

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@caddijp/stylelint-config",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@caddijp/tsconfig",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Shared TypeScript config for CADDi projects",
   "license": "MIT",
   "main": "tsconfig.json",


### PR DESCRIPTION
## v0.2.1 (2021-03-19)

#### :bug: Type: Bug

- [#245](https://github.com/caddijp/frontend/pull/245) fix: typo ([@9renpoto](https://github.com/9renpoto))

#### :rocket: Type: Feature

- `components`
  - [#244](https://github.com/caddijp/frontend/pull/244) feat: use npm workspace ([@9renpoto](https://github.com/9renpoto))

#### Committers: 1

- Keisuke Kan ([@9renpoto](https://github.com/9renpoto))