### PR TITLE
feat: add two rules to the eslint configuration

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -12,6 +12,8 @@ module.exports = {
     'prefer-const': 2,
     'prefer-destructuring': 1,
     'no-console': 1,
+    '@typescript-eslint/array-type': ['warn', { default: 'array' }], // Array<T> => T[], ReadonlyArray<T> => readonly T[]
+    'react/self-closing-comp': ['warn', { component: true, html: true }], // <div></div> => <div />
   },
   parserOptions: {
     ecmaVersion: 2018,


### PR DESCRIPTION
The following two rules were added to the eslint configuration file.

- `Array<T>` is converted to `T[]`; `ReadonlyArray<T>` is also converted to `readonly T[]`.
  - https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/array-type.md 
- Enforce self-closing style
  - https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/self-closing-comp.md